### PR TITLE
Inscription : on demande un nom de joueuse / joueur

### DIFF
--- a/migrations/Version20240805051635.php
+++ b/migrations/Version20240805051635.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240805051635 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Ajout du nom des users';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE user ADD name VARCHAR(255) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE user DROP name');
+    }
+}

--- a/src/Controller/HomeController.php
+++ b/src/Controller/HomeController.php
@@ -25,6 +25,7 @@ class HomeController extends AbstractController
 
         return $this->render('home/index.html.twig', [
             'usercode' => $user->getUserIdentifier(),
+            'name' => $user->getName(),
             'team' => $user->getTeam()->getName(),
             'userScore' => $flashRepository->getUserScore($user->getId()),
             'teamConnexions' => $teamScore['connexions'],

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -26,6 +26,9 @@ class User implements UserInterface
     #[ORM\Column(nullable: true)]
     private ?\DateTimeImmutable $registeredAt = null;
 
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $name = null;
+
     public function getId(): ?int
     {
         return $this->id;
@@ -101,6 +104,27 @@ class User implements UserInterface
     public function setRegisteredAt(?\DateTimeImmutable $registeredAt): static
     {
         $this->registeredAt = $registeredAt;
+
+        return $this;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName(?string $name): static
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function register(): static
+    {
+        if (!$this->registeredAt instanceof \DateTimeImmutable) {
+            $this->registeredAt = new \DateTimeImmutable();
+        }
 
         return $this;
     }

--- a/src/Form/FlashType.php
+++ b/src/Form/FlashType.php
@@ -2,13 +2,11 @@
 
 namespace App\Form;
 
-use App\Validator\CodeExists;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
 
@@ -32,12 +30,5 @@ class FlashType extends AbstractType
             ])
             ->add('save', SubmitType::class, ['label' => 'Valider'])
         ;
-    }
-
-    public function configureOptions(OptionsResolver $resolver): void
-    {
-        $resolver->setDefaults([
-
-        ]);
     }
 }

--- a/src/Form/NameType.php
+++ b/src/Form/NameType.php
@@ -26,8 +26,8 @@ class NameType extends AbstractType
                     new NotBlank(),
                     new Length(min: 3, max: 255, exactMessage: self::INVALID_NAME),
                 ],
-                'label' => 'Comment vous appelez-vous ?',
-                'help' => 'Votre nom sera visible par les autres joueuses et joueurs et doit respecter le <a href="https://coc.afup.org">Code de Conduite</a> de l\'AFUP.',
+                'label' => 'Comment souhaitez-vous qu’on vous appelle ?',
+                'help' => 'Votre nom sera visible par les autres joueuses et joueurs sur le classement général. Il doit respecter le <a href="https://coc.afup.org">Code de Conduite</a> de l\'AFUP.',
                 'help_html' => true,
                 'attr' => [
                     'class' => 'form-control-lg',

--- a/src/Form/NameType.php
+++ b/src/Form/NameType.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Form;
+
+use App\Entity\User;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\Length;
+use Symfony\Component\Validator\Constraints\NotBlank;
+
+class NameType extends AbstractType
+{
+    public const INVALID_NAME = 'Nom invalide : il doit être compris entre 3 et 255 caractères';
+
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('name', TextType::class, [
+                'required' => true,
+                'constraints' => [
+                    new NotBlank(),
+                    new Length(min: 3, max: 255, exactMessage: self::INVALID_NAME),
+                ],
+                'label' => 'Comment vous appelez-vous ?',
+                'help' => 'Votre nom sera visible par les autres joueuses et joueurs et doit respecter le Code de Conduite de l\'AFUP.',
+                'attr' => [
+                    'class' => 'form-control-lg',
+                ],
+            ])
+            ->add('save', SubmitType::class, ['label' => 'Enregistrer et continuer'])
+        ;
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => User::class,
+        ]);
+    }
+}

--- a/src/Form/NameType.php
+++ b/src/Form/NameType.php
@@ -27,7 +27,8 @@ class NameType extends AbstractType
                     new Length(min: 3, max: 255, exactMessage: self::INVALID_NAME),
                 ],
                 'label' => 'Comment vous appelez-vous ?',
-                'help' => 'Votre nom sera visible par les autres joueuses et joueurs et doit respecter le Code de Conduite de l\'AFUP.',
+                'help' => 'Votre nom sera visible par les autres joueuses et joueurs et doit respecter le <a href="https://coc.afup.org">Code de Conduite</a> de l\'AFUP.',
+                'help_html' => true,
                 'attr' => [
                     'class' => 'form-control-lg',
                 ],

--- a/src/Form/RegistrationType.php
+++ b/src/Form/RegistrationType.php
@@ -2,12 +2,10 @@
 
 namespace App\Form;
 
-use App\Validator\CodeExists;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
 

--- a/src/Services/UserRegistration.php
+++ b/src/Services/UserRegistration.php
@@ -16,18 +16,10 @@ final class UserRegistration
         private readonly EntityManagerInterface $em,
     ) {}
 
-    public function register(string $code): User
+    public function register(User $user): void
     {
-        $user = $this->getUser($code);
-
-        if (!$user->getRegisteredAt() instanceof \DateTimeImmutable) {
-            $user->setRegisteredAt(new \DateTimeImmutable());
-        }
-
-        $this->em->persist($user);
-        $this->em->flush();
-
-        return $user;
+        $user->register();
+        $this->save($user);
     }
 
     public function getUser(string $code): User
@@ -39,5 +31,11 @@ final class UserRegistration
         }
 
         return $user;
+    }
+
+    public function save(User $user): void
+    {
+        $this->em->persist($user);
+        $this->em->flush();
     }
 }

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -48,7 +48,7 @@
     {% endif %}
     <ul class="list-inline">
         <li class="list-inline-item"><a href="{{ path('app_rules') }}" class="text-black-50">Règles du jeu</a></li>
-        <li class="list-inline-item"><a href="https://afup.org/p/986-code-de-conduite" class="text-black-50">Code de conduite</a></li>
+        <li class="list-inline-item"><a href="https://coc.afup.org" class="text-black-50">Code de conduite</a></li>
         <li class="list-inline-item"><a href="https://event.afup.org" class="text-black-50">Forum PHP 2024</a></li>
     </ul>
     <p class="mb-1">

--- a/templates/home/index.html.twig
+++ b/templates/home/index.html.twig
@@ -4,7 +4,7 @@
     <div class="container text-center">
         <h1 class="display-5 fw-bold text-body-emphasis">Soirée communautaire : le jeu</h1>
         <div class="col-lg-6 mx-auto">
-            <p class="lead mb-0 mt-4">Vous êtes <span style="font-weight: 600;">{{ usercode }}</span>.</p>
+            <p class="lead mb-0 mt-4">Vous êtes <span style="font-weight: 600;">{{ name }}</span> ({{ usercode }}).</p>
             <p class="lead mb-4">Vous faites partie de l'équipe <span style="font-weight: 600;">{{ team|upper }}</span>.</p>
             <p class="lead mb-4">
                 Vos connexions : <span style="font-weight: 600;">{{ userScore }}</span>

--- a/templates/security/whoami.html.twig
+++ b/templates/security/whoami.html.twig
@@ -1,0 +1,14 @@
+{% extends 'base.html.twig' %}
+
+{% block content %}
+    <div class="container text-center">
+        <h1 class="display-5 fw-bold text-body-emphasis">Votre nom</h1>
+        <div class="col-lg-6 mx-auto">
+            <p class="lead mb-4">Bienvenue <span style="font-weight: 600;">{{ code }}</span> !</p>
+            <p class="lead mb-4">Ne serait-ce plus sympa de vous appeler par vos nom et prénom ?</p>
+
+            {{ form(form) }}
+
+        </div>
+    </div>
+{% endblock %}

--- a/templates/security/whoami.html.twig
+++ b/templates/security/whoami.html.twig
@@ -5,7 +5,7 @@
         <h1 class="display-5 fw-bold text-body-emphasis">Votre nom</h1>
         <div class="col-lg-6 mx-auto">
             <p class="lead mb-4">Bienvenue <span style="font-weight: 600;">{{ code }}</span> !</p>
-            <p class="lead mb-4">Ne serait-ce plus sympa de vous appeler par vos nom et prénom ?</p>
+            <p class="lead mb-4">Ne serait-ce pas plus sympa de vous appeler par votre nom plutôt que par un code ?</p>
 
             {{ form(form) }}
 

--- a/tests/Acceptance/RegisterCest.php
+++ b/tests/Acceptance/RegisterCest.php
@@ -38,11 +38,16 @@ class RegisterCest
         $I->see('Vous souhaitez vous inscrire ou vous reconnecter avec le code C0001.');
 
         $I->click('Oui c\'est bien mon badge !');
+
+        $I->see('Bienvenue C0001 !');
+        $I->fillField('name[name]', 'SuPHPhero');
+        $I->click('Enregistrer et continuer');
+
         $I->see('Merci');
-        $I->see('Vous êtes C0001.');
+        $I->see('Vous êtes SuPHPhero (C0001).');
 
         $I->amOnPage('/register');
         $I->canSeeCurrentUrlEquals('/');
-        $I->see('Vous êtes C0001.');
+        $I->see('Vous êtes SuPHPhero (C0001).');
     }
 }

--- a/tests/Support/Step/Acceptance/AcceptanceUser.php
+++ b/tests/Support/Step/Acceptance/AcceptanceUser.php
@@ -16,7 +16,12 @@ class AcceptanceUser extends AcceptanceTester
         $I->fillField('registration[code]', $usercode);
         $I->click('registration[save]');
         $I->click('Oui c\'est bien mon badge !');
-        $I->see('Vous êtes ' . $usercode . '.');
+        $I->see('Bienvenue ' . $usercode . ' !');
+
+        $I->fillField('name[name]', 'SuPHPhero');
+        $I->click('Enregistrer et continuer');
+
+        $I->see('Vous êtes SuPHPhero (' . $usercode . ').');
     }
 
 }


### PR DESCRIPTION
Après la confirmation que l'on scanne bien son badge personnel, le jeu demande à ce que nous saisissions nos nom et prénom (textes qui pourront être modifiés pour mettre "nom d'utilisateur" ou "nom de jeu" si on préfère).

Aussi dans cette PR il n'est pas directement possible de modifier son nom une fois qu'il a été saisi. C'est possible de modifier soit en demandant le nom à chaque déconnexion/reconnexion au jeu, soit en créant un lien vers la route `app_register_whoami` qui est accessible en tout temps.